### PR TITLE
Add limits and sort labels

### DIFF
--- a/rawdataTools/crossCor.m
+++ b/rawdataTools/crossCor.m
@@ -1,11 +1,13 @@
-function crosscor( data,labels )
+function crosscor( data, labels )
 %crosscor Cross correlation map from analog data
 %   crosscor(data) takes in a NxM matrix with a timeseries of size N 
 %   and M channels. This is used to calculate and plot the crosscorrelation
 %   between each channel, with a lag search of 10 samples.
 %   Requires Signal Processing Toolbox
 
-    tic
+    % Limits to the colorbar [min max]
+    colorLimits = [0 1];
+
     nChannels = size(data,2);
     cc = zeros(nChannels,nChannels);
     for chan1Index = 1:nChannels
@@ -25,11 +27,12 @@ function crosscor( data,labels )
     end
     [labels,s ]= sort(labels);
     cc = cc(s,s);
-    toc
     
+    % Plot heatmap
     figure;
     imagesc(cc);
     colorbar;
+    caxis(colorLimits)
     set(gca, 'XTick', 1:length(labels), 'XTickLabel', labels)
     set(gca, 'YTick', 1:length(labels), 'YTickLabel', labels)
     grid on;
@@ -38,8 +41,9 @@ function crosscor( data,labels )
     xlabel('Electrodes')
     ylabel('Electrodes')
     
-    cfg=[];
+    % Plot directional graph
+    cfg = [];
     cfg.title = 'Cross correlation';
-    dirgraph(cc,labels,1,cfg);
+    dirgraph(cc, labels, 1, cfg);
 end
 

--- a/rawdataTools/plotPDS.m
+++ b/rawdataTools/plotPDS.m
@@ -1,8 +1,11 @@
-function  plotPDS( signal,fs,chan)
+function  plotPDS(signal, fs, chan)
 %plotPDS Plot the periodogram of one channel
 %   plotPDS( SIGNAL,FS,CHAN) plots the periodogram with the power spectrum
 %   of SIGNAL with sampling rate FS. CHAN is a string with the name of the
 %   signal. Requires Signal Processing Toolbox
+
+    % Hardcoded cutoff range
+    limits = [0 3e9];
 
     figure;
     [P,f] = periodogram(signal,[],[],fs,'power');
@@ -11,5 +14,6 @@ function  plotPDS( signal,fs,chan)
     ylabel('Power');
     xlabel('Frequency [Hz]');
     title(['Power Spectrum - Channel ' chan]);
+    ylim(limits); 
 end
 

--- a/spiketrainTools/barGraph.m
+++ b/spiketrainTools/barGraph.m
@@ -9,6 +9,15 @@ function barGraph(timeStamps,labels)
     for index=1:nChannels
        bargraph(index) = numel(timeStamps{index}); 
     end
+    
+    % Replace channel label 'Ref' with '15'
+    refIndex = find(contains(labels,'Ref'));
+    if refIndex ~= 0 
+        labels{refIndex} = '15'; 
+    end
+    [labels,s ]= sort(labels);
+    bargraph = bargraph(s,s);
+    
     figure;
     bar(bargraph);
     xlim([0 nChannels+1])

--- a/spiketrainTools/plotMFR.m
+++ b/spiketrainTools/plotMFR.m
@@ -5,29 +5,32 @@ function plotMFR( timeStamps,labels,duration )
 %   the selected recordring, and generates a heatmap of the mean firing rate
 %   for each channel.
     
+    % Limits to the colorbar [min max]
+    colorLimits = [0 40];
+
     label = 11;
     heat = zeros(8,8);
     for j = 1:8
         for i = 1:8
             if ~((i==1 || i==8)&& (j==1 || j==8))
                 if label == 15 % Channel 15 is called 'Ref' in the data
-                    index =find(contains(labels,'Ref','IgnoreCase',true));
+                    index =find(contains(labels, 'Ref', 'IgnoreCase', true));
                 else
-                    index =find(contains(labels,num2str(label),'IgnoreCase',true));
+                    index =find(contains(labels, num2str(label), 'IgnoreCase', true));
                 end
-                heat(i,j) = numel(timeStamps{index})/duration;
+                heat(i,j) = numel(timeStamps{index}) / duration;
             end
             if mod(label,10) < 8
-                label = label +1;
+                label = label + 1;
             else
-            label = label +3;
+            label = label + 3;
             end
         end
     end
     figure;
-    heatmap(heat);
+    h = heatmap(heat);
+    h.ColorLimits = colorLimits;
     title('Mean firing rate [spike/s]')
-
 
     % Replace channel label 'Ref' with '15'
     refIndex = find(contains(labels,'Ref'));
@@ -44,6 +47,7 @@ function plotMFR( timeStamps,labels,duration )
     cfg = [];
     cfg.title = 'Mean firing rate';
     cfg.cbLabel = '[spike/s]';
-    plot_layout(mfr,labels,cfg);
+    cfg.colorLim = colorLimits;
+    plot_layout(mfr, labels, cfg);
 end
 

--- a/spiketrainTools/rasterplot.m
+++ b/spiketrainTools/rasterplot.m
@@ -4,6 +4,17 @@ function rasterplot( timeStampData )
 %   Takes in a time stamp data object (McsTimeStampStream) 
 %   and generates a heatmap with number of spikes per channel
 
+    timeStamps = timeStampData.TimeStamps;
+    labels = timeStampData.Info.Label;
+    
+    % Replace channel label 'Ref' with '15'
+    refIndex = find(contains(labels,'Ref'));
+    if refIndex ~= 0 
+        labels{refIndex} = '15'; 
+    end
+    [timeStampData.Info.Label, s] = sort(labels);
+    timeStampData.TimeStamps = timeStamps(s);
+ 
     figure;
     plot(timeStampData,[]); 
     title('Rasterplot');

--- a/utils/plot_layout.m
+++ b/utils/plot_layout.m
@@ -10,7 +10,8 @@ function plot_layout(channels,labels,cfg)
 %   Example:
 %       cfg=[];
 %       cfg.title = 'Some title';
-%       cfg.cbLabel = 'Label of the right colorbar'; 
+%       cfg.cbLabel = 'Label of the right colorbar';
+%       cfg.colorLim = [0 50] % Limits on colorbar [min max]
 
     refIndex = find(contains(labels,'Ref'));
     if refIndex ~= 0 
@@ -53,9 +54,17 @@ function plot_layout(channels,labels,cfg)
     end
     set(hAxesNode,'xtick',[]);
     set(hAxesNode,'ytick',[]);
+    
+    % Specify title
     if isfield(cfg, 'title')
         title(cfg.title)
     end
+    
+    % Add limits on colorbar
+    if isfield(cfg, 'colorLim')
+        caxis(hAxesNode, cfg.colorLim);
+    end
+    
 end
 
 


### PR DESCRIPTION
Added a new option to plot_layout to specify range in colorbar:
  * cfg.colorLim = [min max]

  * New colorlimit in MFR set to [0 40]
  * New colorlimit in CC set to [0 1]

Added limits on y-axis in PSD, set to [0 3e9]

Added sorting of labels in bargraph and rasterplot in case of inconsistency
in the order of channel labels.

**DISCLAIMER:** This update is not tested on a recording.